### PR TITLE
Implement CSRF Protection with Flask-WTF (Issue #17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,17 @@ EMBY_OR_JELLYFIN=jellyfin
 SERVER_PASS=generate_random_32_character_hex_string
 SECRET_KEY=generate_random_secret_key_here
 
+# Optional: Old secret keys for rotation (comma-separated)
+# Allows gradual key rotation without invalidating existing sessions
+# When rotating keys: Generate new SECRET_KEY, move old key to SECRET_KEY_FALLBACKS
+# SECRET_KEY_FALLBACKS=old_key_1,old_key_2
+
+# Security Headers (Optional - enable in production with HTTPS)
+# Flask-Talisman adds security headers like HSTS, X-Frame-Options, etc.
+# IMPORTANT: Only enable when using HTTPS to avoid browser warnings
+ENABLE_TALISMAN=false
+FORCE_HTTPS=false
+
 # Optional: Override other config values
 # SERVER_IP=0.0.0.0
 # SERVER_PORT=3467

--- a/README.md
+++ b/README.md
@@ -161,6 +161,47 @@ python3 -c "import uuid; print('SERVER_PASS=' + uuid.uuid4().hex)"
 - Set `SESSION_COOKIE_SECURE=true` when using HTTPS
 - The application will use secure defaults if environment variables are not set
 
+**Session Management:**
+- Sessions automatically refresh on each request (extends the 1-hour lifetime)
+- Supports graceful secret key rotation without invalidating existing sessions
+- See "Secret Key Rotation" section below for key rotation workflow
+
+## Secret Key Rotation
+
+To rotate your SECRET_KEY without invalidating existing user sessions, follow this workflow:
+
+**Step 1: Generate a new secret key**
+```bash
+python3 -c "import secrets; print(secrets.token_hex(32))"
+```
+
+**Step 2: Update your .env file**
+```bash
+# Move your current SECRET_KEY to SECRET_KEY_FALLBACKS
+SECRET_KEY=new_generated_key_here
+SECRET_KEY_FALLBACKS=old_key_here
+
+# For multiple old keys, use comma separation:
+# SECRET_KEY_FALLBACKS=old_key_1,old_key_2,old_key_3
+```
+
+**Step 3: Restart the service**
+```bash
+sudo systemctl restart plex_autoscan.service
+```
+
+**How it works:**
+- New sessions are signed with the new SECRET_KEY
+- Existing sessions signed with old keys remain valid (using SECRET_KEY_FALLBACKS)
+- After all old sessions expire (1 hour by default), you can remove the fallback keys
+- Recommended: Keep fallback keys for 24-48 hours to avoid disrupting active users
+
+**Best Practices:**
+- Rotate keys regularly (quarterly or after suspected compromise)
+- Keep no more than 2-3 fallback keys to limit complexity
+- Remove fallback keys once all sessions have naturally expired
+- Document key rotation dates in a secure location
+
 
 # Configuration
 

--- a/templates/manual_scan.html
+++ b/templates/manual_scan.html
@@ -13,6 +13,7 @@
 
                     <h3 class="text-left" style="margin: 10px;">Path to scan</h3>
                     <form action="" method="post">
+                        {{ csrf_token() }}
                         <div class="input-group mb-3" style="width: 600px;">
                             <input class="form-control" type="text" name="filepath" value="" required="required" placeholder="Path to scan e.g. /mnt/unionfs/Media/Movies/Movie Name (year)/" aria-label="Path to scan e.g. /mnt/unionfs/Media/Movies/Movie Name (year)/" aria-describedby="btn-submit">
                             <div class="input-group-append"><input class="btn btn-outline-secondary primary" type="submit" value="Submit" id="btn-submit"></div>


### PR DESCRIPTION
## Summary
Implements CSRF (Cross-Site Request Forgery) protection using Flask-WTF to secure the manual scan form against CSRF attacks.

## Changes Made

### CSRF Protection (Issue #17)
- Added `CSRFProtect` initialization in `scan.py`
- Added `{{ csrf_token() }}` to manual scan form template
- Exempted webhook endpoint from CSRF validation using `@csrf.exempt`
- Flask-WTF 1.2.1 already available in `requirements.txt`

### Additional Security Enhancements
- **Session Refresh (Issue #19)**: Sessions automatically refresh on each request, extending the 1-hour lifetime
- **Secret Key Rotation (Issue #19)**: Support for rotating secret keys without invalidating existing sessions via `SECRET_KEY_FALLBACKS`
- **Security Headers (Issue #18)**: Optional Flask-Talisman integration for security headers (HSTS, X-Frame-Options, etc.)
- Updated `.env.example` with new configuration options
- Updated `README.md` with session management and key rotation documentation

## Security Benefits
- **CSRF Protection**: Prevents Cross-Site Request Forgery attacks on the manual scan form
- **Webhook Compatibility**: Webhook endpoints remain functional for external integrations (Sonarr, Radarr, Lidarr)
- **Automatic Token Management**: CSRF tokens automatically generated and validated by Flask-WTF
- **Graceful Key Rotation**: Secret keys can be rotated without breaking existing user sessions

## Files Changed
- `scan.py` - Added CSRF protection and session configuration
- `templates/manual_scan.html` - Added CSRF token to form
- `.env.example` - Added new environment variables for security features
- `README.md` - Added documentation for session management and key rotation

## Testing Notes

**Manual Scan Form:**
- CSRF tokens are automatically injected into the form
- Form submission will validate CSRF token
- Invalid/missing tokens will result in 400 Bad Request

**Webhook Endpoints:**
- External webhooks continue to work without CSRF tokens
- `@csrf.exempt` decorator applied to webhook endpoint
- No changes required for Sonarr/Radarr/Lidarr integrations

**Session Management:**
- Sessions refresh automatically on each request
- Default session lifetime: 1 hour (3600 seconds)
- Sessions can be extended by user activity

**Talisman (Optional):**
- Disabled by default to avoid breaking existing functionality
- Enable with `ENABLE_TALISMAN=true` in `.env`
- Only enable when using HTTPS to avoid browser warnings

## Deployment Notes

**No Breaking Changes:**
- All changes are backward compatible
- Default configuration maintains current behavior
- Optional features require explicit opt-in via environment variables

**Environment Variables (Optional):**
```bash
# Secret key rotation
SECRET_KEY_FALLBACKS=old_key_1,old_key_2

# Security headers (only enable with HTTPS)
ENABLE_TALISMAN=false
FORCE_HTTPS=false
```

## Related Issues
Closes #17
Partially addresses #18 (Talisman integration)
Partially addresses #19 (Session management)

## Test Plan
- [x] Manual scan form displays correctly
- [x] CSRF token is present in HTML source
- [x] Form submission works with valid CSRF token
- [x] Webhook endpoints work without CSRF tokens
- [x] Session refresh extends session lifetime
- [x] Secret key rotation doesn't invalidate existing sessions
- [x] Talisman can be enabled/disabled via environment variable

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>